### PR TITLE
README: Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@ import { expect } from "chai";
 import { createBuilder, createTempDir } from "broccoli-test-helper";
 import MyBroccoliPlugin from "../index";
 
-describe("MyBroccoliPlugin", () => {
+describe("MyBroccoliPlugin", function() {
   let input;
   let output;
   let subject;
 
-  beforeEach(async () => {
+  beforeEach(async function() {
     input = await createTempDir();
     subject = new MyBroccoliPlugin(input.path());
     output = createBuilder(subject);
   });
 
-  afterEach(async () => {
+  afterEach(async function() {
     await input.dispose();
     await output.dispose();
   });
 
-  it("should build", async () => {
+  it("should build", async function() {
     input.write({
       "index.js": `export { A } from "./lib/a";`,
       "lib": {


### PR DESCRIPTION
In Mocha `this` is referring to the test context which has a few special methods to adjust the test run. When using arrow functions `this` is pointing to something else though, which remove the possibility of using those Mocha APIs, which is the reason why anonymous functions should be used for Mocha blocks.

